### PR TITLE
Release v0.0.0

### DIFF
--- a/data/com.github.timecraft.js-test.appdata.xml.in
+++ b/data/com.github.timecraft.js-test.appdata.xml.in
@@ -52,6 +52,12 @@
     </content_rating>
 
     <releases>
+        <release version="0.0.0" date="2019-11-13" urgency="low">
+            <description>
+                There is no change from this release to version 0.1.0.<br/>
+                This release should not be used.
+            </description>
+        </release>
         <release version="0.1.0" date="2019-11-13" urgency="low">
             <description>
                 Initial release to AppCenter


### PR DESCRIPTION
Dummy release; use v0.1.0

This release will be deleted as soon as it is verified that the release automation is working